### PR TITLE
Install all project dependencies.

### DIFF
--- a/chassis.yaml
+++ b/chassis.yaml
@@ -11,6 +11,6 @@ version: 2
 dependencies:
   - composer
   - grunt
-  - kadamwhite/phpunit
+  - kadamwhite/phpunit # TODO: update once extension moves to Chassis org.
   - nodejs
   - npm

--- a/chassis.yaml
+++ b/chassis.yaml
@@ -6,7 +6,11 @@
 # Values: 2
 version: 2
 
+# Chassis extension dependencies. Any unprefixed dependency is assumed to be
+# a repository within the Chassis GitHub organization.
 dependencies:
   - composer
-  - npm
   - grunt
+  - kadamwhite/phpunit
+  - nodejs
+  - npm

--- a/modules/core-dev/manifests/init.pp
+++ b/modules/core-dev/manifests/init.pp
@@ -40,6 +40,11 @@ class core-dev (
 	# 	]
 	# }
 
+	# Ensure SVN is installed.
+	package { 'subversion':
+		ensure => 'present',
+	}
+
 	# package { 'php-package-name':
 	# 	ensure  => $package
 	# }

--- a/modules/core-dev/manifests/init.pp
+++ b/modules/core-dev/manifests/init.pp
@@ -20,33 +20,33 @@
 class core-dev (
 	$config
 ) {
-	# Create vagrant-core.local
-	chassis::site { 'vagrant-core.local':
-		location          => '/vagrant/wordpress-develop/src',
-		wpdir             => '/vagrant/wordpress-develop/src',
-		contentdir        => '/vagrant/wordpress-develop/src/wp-content',
-		hosts             => ['vagrant-core.local'],
-		database          => 'vagrantcore_local',
-		database_user     => $config[database][user],
-		database_password => $config[database][password],
-		admin_user        => $config[admin][user],
-		admin_email       => $config[admin][email],
-		admin_password    => $config[admin][password],
-		sitename          => $config[site][name],
-		require => [
-			Class['chassis::php'],
-			Package['git-core'],
-			Class['mysql::server'],
-		]
-	}
+	# # Create vagrant-core.local
+	# chassis::site { 'vagrant-core.local':
+	# 	location          => '/vagrant/wordpress-develop/src',
+	# 	wpdir             => '/vagrant/wordpress-develop/src',
+	# 	contentdir        => '/vagrant/wordpress-develop/src/wp-content',
+	# 	hosts             => ['vagrant-core.local'],
+	# 	database          => 'vagrantcore_local',
+	# 	database_user     => $config[database][user],
+	# 	database_password => $config[database][password],
+	# 	admin_user        => $config[admin][user],
+	# 	admin_email       => $config[admin][email],
+	# 	admin_password    => $config[admin][password],
+	# 	sitename          => $config[site][name],
+	# 	require => [
+	# 		Class['chassis::php'],
+	# 		Package['git-core'],
+	# 		Class['mysql::server'],
+	# 	]
+	# }
 
-# 	package { 'php-package-name':
-# 		ensure  => $package
-# 	}
-#
-# 	file { '/tmp/randomfile.ini':
-# 		ensure => $file,
-# 		content => '# Example content',
-# 		force  => true
-# 	}
+	# package { 'php-package-name':
+	# 	ensure  => $package
+	# }
+
+	# file { '/tmp/randomfile.ini':
+	# 	ensure => $file,
+	# 	content => '# Example content',
+	# 	force  => true
+	# }
 }

--- a/modules/core-dev/manifests/init.pp
+++ b/modules/core-dev/manifests/init.pp
@@ -1,22 +1,4 @@
-# Example Puppet class!
-#
-# Chassis automatically loads your class, and passes $config in, which is an
-# array representing the YAML-based configuration. You can use this to access
-# Chassis configuration, or your own custom keys. In this demo, we've used
-# `show_example`. To test it out, add the following to your config:
-#
-#     show_example: hello!
-#
-# The entirety of your behaviour should be wrapped inside this class.
-#
-# ***********************************
-#          IMPORTANT NOTES:
-#
-# * Your module directory must be named the same as the extension.
-# * Your class must be in init.pp, and named the same as the extension.
-#
-# ***********************************
-
+# Class to prepare the Chassis box for WP core development.
 class core-dev (
 	$config
 ) {

--- a/modules/core-dev/manifests/init.pp
+++ b/modules/core-dev/manifests/init.pp
@@ -39,15 +39,7 @@ class core-dev (
 			Class['mysql::server'],
 		]
 	}
-# This is an example of how you can use disabled_extensions in the yaml files to add or remove packages.
-# 	if ( ! empty( $config[disabled_extensions] ) and 'chassis/example' in $config[disabled_extensions] ) {
-# 		$package = absent
-# 		$file    = absent
-# 	} else {
-# 		$package = latest
-# 		$file    = present
-# 	}
-#
+
 # 	package { 'php-package-name':
 # 		ensure  => $package
 # 	}


### PR DESCRIPTION
- Adds a dependency on `kadamwhite/phpunit` (soon to be `chassis/phpunit`, with some luck)
- Adds a provisioning command to install SVN in case this comes in handy for creating a local checkout

Closes #11

Incidentally removes the commented-out boilerplate in `init.pp` designed to permit disabling this extension using `disabled_extensions`; going that route felt like it would be substantive overkill in terms of added complexity. If you're using this extension, you want to use this extension. If you don't want it, remove it.