### PR TITLE
Add wordpress-develop directory to Chassis ignore list

### DIFF
--- a/modules/core-dev/manifests/init.pp
+++ b/modules/core-dev/manifests/init.pp
@@ -27,6 +27,18 @@ class core-dev (
 		ensure => 'present',
 	}
 
+	# Instruct Chassis checkout to wordpress-develop folder.
+	exec { 'git_exclude_exists':
+		command => '/bin/false',
+		unless => '/usr/bin/test -e /vagrant/.git/info/exclude',
+	}
+
+	file_line { 'ignore wordpress-develop directory':
+		path => '/vagrant/.git/info/exclude',
+		line => 'wordpress-develop',
+		require => Exec['git_exclude_exists']
+	}
+
 	# package { 'php-package-name':
 	# 	ensure  => $package
 	# }


### PR DESCRIPTION
This is tricksy magic, a bit, but it's the cleanest way I've found to ensure that the `wordpress-develop` directory (into which we intend to check out the repo) is fully ignored by the parent Chassis git checkout.