### PR TITLE
Checkout default repo

### DIFF
--- a/modules/core-dev/manifests/init.pp
+++ b/modules/core-dev/manifests/init.pp
@@ -44,6 +44,13 @@ class core-dev (
 		creates => '/vagrant/wordpress-develop'
 	}
 
+	exec { 'maybe_create_build_directory':
+		# Ensure directory exists for nginx but developers must run grunt build.
+		command => '/bin/mkdir -p /vagrant/wordpress-develop/build',
+		creates => '/vagrant/wordpress-develop/build',
+		require => Exec['maybe_checkout_wp_develop']
+	}
+
 	# package { 'php-package-name':
 	# 	ensure  => $package
 	# }

--- a/modules/core-dev/manifests/init.pp
+++ b/modules/core-dev/manifests/init.pp
@@ -51,6 +51,13 @@ class core-dev (
 		require => Exec['maybe_checkout_wp_develop']
 	}
 
+	# Create wp-config.php
+	file { '/vagrant/wordpress-develop/wp-config.php':
+		ensure  => $file,
+		mode    => '0644',
+		content => template('core-dev/wp-config.php.erb')
+	}
+
 	# package { 'php-package-name':
 	# 	ensure  => $package
 	# }

--- a/modules/core-dev/manifests/init.pp
+++ b/modules/core-dev/manifests/init.pp
@@ -39,6 +39,11 @@ class core-dev (
 		require => Exec['git_exclude_exists']
 	}
 
+	exec { 'maybe_checkout_wp_develop':
+		command => '/usr/bin/git clone git://develop.git.wordpress.org/ /vagrant/wordpress-develop',
+		creates => '/vagrant/wordpress-develop'
+	}
+
 	# package { 'php-package-name':
 	# 	ensure  => $package
 	# }

--- a/modules/core-dev/templates/wp-config.php.erb
+++ b/modules/core-dev/templates/wp-config.php.erb
@@ -1,0 +1,120 @@
+<?php
+// ===================================================
+// Editing of this file is discouraged. Create a local-config.php to define custom constants.
+// ===================================================
+
+// ===================================================
+// Load database info and local development parameters
+// ===================================================
+if ( file_exists( dirname( __DIR__ ) . '/local-config-db.php' ) ) {
+	define( 'WP_LOCAL_DEV', true );
+	include( dirname( __DIR__ ) . '/local-config-db.php' );
+}
+
+if ( file_exists( dirname( __DIR__ ) . '/local-config.php' ) ) {
+	defined('WP_LOCAL_DEV') or define( 'WP_LOCAL_DEV', true );
+	include( dirname( __DIR__ ) . '/local-config.php' );
+} elseif ( ! defined('WP_LOCAL_DEV') ) {
+	define( 'WP_LOCAL_DEV', false );
+	define( 'DB_NAME', '%%DB_NAME%%' );
+	define( 'DB_USER', '%%DB_USER%%' );
+	define( 'DB_PASSWORD', '%%DB_PASSWORD%%' );
+	define( 'DB_HOST', '%%DB_HOST%%' ); // Probably 'localhost'
+}
+
+// =======================================
+// Check that we actually have a DB config
+// =======================================
+if ( ! defined( 'DB_HOST' ) || strpos( DB_HOST, '%%' ) !== false ) {
+	header('X-WP-Error: dbconf', true, 500);
+	echo '<h1>Database configuration is incomplete.</h1>';
+	echo "<p>If you're developing locally, ensure you have a local-config.php.
+	If this is in production, deployment is broken.</p>";
+	die(1);
+}
+
+// =======================
+// Load Chassis extensions
+// =======================
+if ( file_exists( dirname( __DIR__ ) . '/local-config-extensions.php' ) ) {
+	include( dirname( __DIR__ ) . '/local-config-extensions.php' );
+}
+
+// ==================
+// Set up WP location
+// ==================
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+// ======================================
+// Fake HTTP Host (for CLI compatibility)
+// ======================================
+if ( ! isset( $_SERVER['HTTP_HOST'] ) ) {
+	if ( defined( 'DOMAIN_CURRENT_SITE' ) ) {
+		$_SERVER['HTTP_HOST'] = DOMAIN_CURRENT_SITE;
+	} else {
+		$_SERVER['HTTP_HOST'] = 'vagrant.local';
+	}
+}
+
+// =====================
+// URL hacks for Vagrant
+// =====================
+if ( WP_LOCAL_DEV && ! defined('WP_SITEURL') && ! defined( 'WP_INSTALLING' ) ) {
+	define('WP_SITEURL', 'http://' . $_SERVER['HTTP_HOST'] );
+
+	if ( ! defined( 'WP_HOME' ) ) {
+		define('WP_HOME', 'http://' . $_SERVER['HTTP_HOST']);
+	}
+}
+
+// ================================================
+// You almost certainly do not want to change these
+// ================================================
+define( 'DB_CHARSET', 'utf8' );
+define( 'DB_COLLATE', '' );
+
+// ==============================================================
+// Salts, for security
+// Grab these from: https://api.wordpress.org/secret-key/1.1/salt
+// ==============================================================
+define( 'AUTH_KEY',         'put your unique phrase here' );
+define( 'SECURE_AUTH_KEY',  'put your unique phrase here' );
+define( 'LOGGED_IN_KEY',    'put your unique phrase here' );
+define( 'NONCE_KEY',        'put your unique phrase here' );
+define( 'AUTH_SALT',        'put your unique phrase here' );
+define( 'SECURE_AUTH_SALT', 'put your unique phrase here' );
+define( 'LOGGED_IN_SALT',   'put your unique phrase here' );
+define( 'NONCE_SALT',       'put your unique phrase here' );
+
+// ==============================================================
+// Table prefix
+// Change this if you have multiple installs in the same database
+// ==============================================================
+if ( empty( $table_prefix ) ) {
+	$table_prefix  = 'wp_';
+}
+
+// =====================================
+// Errors
+// Show/hide errors for local/production
+// =====================================
+if ( WP_LOCAL_DEV ) {
+	defined( 'WP_DEBUG' ) or define( 'WP_DEBUG', true );
+}
+// Only override if not already set
+elseif ( ! defined( 'WP_DEBUG_DISPLAY' ) ) {
+	ini_set( 'display_errors', 0 );
+	define( 'WP_DEBUG_DISPLAY', false );
+}
+
+// ===================
+// Bootstrap WordPress
+// ===================
+if ( ! file_exists( ABSPATH . 'wp-settings.php' ) ) {
+	header('X-WP-Error: wpmissing', true, 500);
+	echo '<h1>WordPress is missing.</h1>';
+	die(1);
+}
+require_once( ABSPATH . 'wp-settings.php' );


### PR DESCRIPTION
* [x] clone git://develop.git.wordpress.org/ into `/vagrant/wordpress-develop` if the directory doesn't exist
* [x] Ensure the build directory exists, regardless of whether WP is built.

See #8 

