### PR TITLE
Check out the repository if it is not already present.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "modules/vcsrepo"]
+	path = modules/vcsrepo
+	url = https://github.com/puppetlabs/puppetlabs-vcsrepo.git

--- a/modules/core-dev/manifests/init.pp
+++ b/modules/core-dev/manifests/init.pp
@@ -1,3 +1,5 @@
+include vcsrepo
+
 # Class to prepare the Chassis box for WP core development.
 class core-dev (
 	$config
@@ -22,21 +24,15 @@ class core-dev (
 	# 	]
 	# }
 
-	# Ensure SVN is installed.
-	package { 'subversion':
-		ensure => 'present',
+	class { 'core-dev::repository':
+		config => $config,
 	}
 
-	# Instruct Chassis checkout to wordpress-develop folder.
-	exec { 'git_exclude_exists':
-		command => '/bin/false',
-		unless => '/usr/bin/test -e /vagrant/.git/info/exclude',
-	}
-
-	file_line { 'ignore wordpress-develop directory':
-		path => '/vagrant/.git/info/exclude',
-		line => 'wordpress-develop',
-		require => Exec['git_exclude_exists']
+	# Once the repository exists, ensure the build directory is present
+	# for use as an Nginx site root.
+	file { '/vagrant/wordpress-develop/build':
+		ensure  => 'directory',
+		require => Class['core-dev::repository'],
 	}
 
 	# package { 'php-package-name':

--- a/modules/core-dev/manifests/init.pp
+++ b/modules/core-dev/manifests/init.pp
@@ -1,5 +1,3 @@
-include vcsrepo
-
 # Class to prepare the Chassis box for WP core development.
 class core-dev (
 	$config

--- a/modules/core-dev/manifests/repository.pp
+++ b/modules/core-dev/manifests/repository.pp
@@ -1,0 +1,61 @@
+include vcsrepo
+
+# Class to prepare the Chassis box for WP core development.
+class core-dev::repository (
+	$config
+) {
+	# Ensure SVN is installed.
+	package { 'subversion':
+		ensure => 'present',
+	}
+
+	# Validate a .git/info/exclude file exists for the Chassis checkout.
+	exec { 'git_exclude_exists':
+		command => '/bin/false',
+		unless  => '/usr/bin/test -e /vagrant/.git/info/exclude',
+	}
+
+	# Ignore wordpress-develop folder within the parent Chassis checkout.
+	file_line { 'ignore wordpress-develop directory':
+		path    => '/vagrant/.git/info/exclude',
+		line    => 'wordpress-develop',
+		require => Exec['git_exclude_exists'],
+	}
+
+	# Ensure the repository destination directory exists.
+	file { '/vagrant/wordpress-develop':
+		ensure => 'directory',
+	}
+
+	# vcsrepo task may fail unless GitHub is listed in known_hosts.
+	exec { 'Add github to known_hosts':
+		command => '/usr/bin/ssh-keyscan -t rsa github.com >> /home/vagrant/.ssh/known_hosts',
+		unless  => '/bin/grep -Fxq "github.com" /home/vagrant/.ssh/known_hosts',
+	}
+
+	# Test whether a checkout already exists in the target location.
+	exec { 'wp_dev_checkout_missing':
+		command => '/bin/true',
+		unless  => '/usr/bin/test -f /vagrant/wordpress-develop/package.json',
+	}
+
+	# Permit a develop repo mirror remote to be specified in config.local.yaml.
+	if ( !empty($config['core-dev']) and !empty($config['core-dev']['mirror']) ) {
+		$repository_remotes = {
+			'origin' => 'git://develop.git.wordpress.org/',
+			'mirror' => $config['core-dev']['mirror']
+		}
+	} else {
+		$repository_remotes = { 'origin' => 'git://develop.git.wordpress.org/' }
+	}
+
+	# Otherwise, if no repo is present, check out the repository and set up remotes.
+	vcsrepo { '/vagrant/wordpress-develop':
+		ensure   => present,
+		provider => git,
+		remote   => 'origin',
+		source   => $repository_remotes,
+		user     => 'vagrant',
+		require  => Exec['wp_dev_checkout_missing'],
+	}
+}


### PR DESCRIPTION
This adapts #14 with an alternate approach, using the vcsrepo Puppet module. I've extracted all repo-specific tasks into their own class. That class does these things:

- Add `wordpress-develop` to the .git/info/exclude file in the parent Chassis repo (this was already done in master, it's just been moved)
- Install Subversion (may not be necessary long-term but felt like a good thing to take care of now)
- Ensure github.com is in the VM's `known_hosts` file so that GitHub checkouts will work if the user specifies an alternate mirror.
- Check whether there's already a repository checkout in `wordpress-develop`
- If there is not, clone the develop repository into that directory, and configure the remotes
- Once the repository is set up, create the build folder

Available configuration options:

```yml
# You can use synced_folders to map an existing checkout into
# the VM, in which case a new copy will not be pulled down
synced_folders:
    ../path-to-existing-checkout-on-host: /vagrant/wordpress-develop

# The core-dev key holds properties to configure this extension.
# Pertinently to this work, a `mirror` may be specified to add a
# remote to the develop repo checkout.
core:
    mirror: git@github.com:kadamwhite/wordpress-develop.git
```