### PR TITLE
Install src and build sites

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# Top-most EditorConfig file (see EditorConfig.org)
+root = true
+
+# Unix-style newlines with a newline ending every file
+# Tab indentation most places
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = tab
+trim_trailing_whitespace = true
+
+# YAML files require spaces
+[*.{yaml,yml}]
+indent_style = space
+indent_size = 4

--- a/README.md
+++ b/README.md
@@ -1,5 +1,40 @@
-# wordpress-core-development
-A Chassis extension for WordPress Core development.
+# WordPress Core Development Extension for Chassis
+
+This extension configures a [Chassis](http://chassis.io) virtual machine for WordPress core development.
+
+## Quick Start
+
+Clone Chassis into the directory of your choice with this command:
+
+```bash
+# You may change core-dev-vm to the folder name of your choice.
+git clone --recursive https://github.com/Chassis/Chassis core-dev-vm
+```
+
+Then, create a basic Chassis `config.local.yaml` file in the root of the Chassis checkout, and paste in these options:
+
+```yaml
+# Specify the .local hostname of your choice.
+host:
+  - core.local
+
+# Instruct Chassis to use this extension.
+extensions:
+    - peterwilsoncc/core-dev
+
+# Run in multisite mode (totally optional)
+multisite: false
+
+```
+
+After creating this file, run `vagrant up` to initialize the virtual machine.
+
+Once provisioned, your new WordPress development sites will be available at (using the example hostname above),
+
+- [core.local/src](http://core.local/src): The `src` folder of the WordPress development repository checkout.
+- [core.local/build](http://core.local/src): The `build` folder of the WordPress development repository checkout.
+
+The default username and password for each site is `admin` / `password`, and by default the sites will share a database.
 
 ## Extension Options
 

--- a/modules/core-dev/manifests/build.pp
+++ b/modules/core-dev/manifests/build.pp
@@ -1,0 +1,41 @@
+# Class to install dependencies and build WordPress into `/src` and `/build`.
+class core-dev::build () {
+	exec { 'npm install':
+		command => '/usr/bin/npm install',
+		cwd     => '/vagrant/wordpress-develop',
+		user    => 'vagrant',
+		creates => '/vagrant/wordpress-develop/package-lock.json',
+	}
+
+	# Run grunt to build the project into /vagrant/wordpress-develop/build.
+	exec { 'grunt build':
+		command => '/usr/bin/grunt build',
+		cwd     => '/vagrant/wordpress-develop',
+		user    => 'vagrant',
+		require => Exec['npm install'],
+	}
+
+	# Run grunt to build the project in situ within /vagrant/wordpress-develop/src.
+	exec { 'grunt build --dev':
+		command => '/usr/bin/grunt build --dev',
+		cwd     => '/vagrant/wordpress-develop',
+		user    => 'vagrant',
+		require => Exec['npm install'],
+	}
+
+	# Symlink /build into the nginx root.
+	file { '/vagrant/build':
+		ensure => link,
+		target => '/vagrant/wordpress-develop/build',
+		notify => Service['nginx'],
+		require => Exec['grunt build'],
+	}
+
+	# Symlink /src into the nginx root.
+	file { '/vagrant/src':
+		ensure => link,
+		target => '/vagrant/wordpress-develop/src',
+		notify => Service['nginx'],
+		require => Exec['grunt build --dev'],
+	}
+}

--- a/modules/core-dev/manifests/build.pp
+++ b/modules/core-dev/manifests/build.pp
@@ -1,40 +1,20 @@
 # Class to install dependencies and build WordPress into `/src` and `/build`.
-class core-dev::build () {
-	exec { 'npm install':
-		command => '/usr/bin/npm install',
+define core-dev::build (
+	$grunt_command,
+) {
+	# Run grunt to build the project.
+	exec { "grunt ${ grunt_command }":
+		command => "/usr/bin/grunt ${ grunt_command }",
 		cwd     => '/vagrant/wordpress-develop',
 		user    => 'vagrant',
-	}
-
-	# Run grunt to build the project into /vagrant/wordpress-develop/build.
-	exec { 'grunt build':
-		command => '/usr/bin/grunt build',
-		cwd     => '/vagrant/wordpress-develop',
-		user    => 'vagrant',
-		require => Exec['npm install'],
-	}
-
-	# Run grunt to build the project in situ within /vagrant/wordpress-develop/src.
-	exec { 'grunt build --dev':
-		command => '/usr/bin/grunt build --dev',
-		cwd     => '/vagrant/wordpress-develop',
-		user    => 'vagrant',
-		require => Exec['npm install'],
+		require => Class['grunt'],
 	}
 
 	# Symlink /build into the nginx root.
-	file { '/vagrant/build':
+	file { "/vagrant/${ name }/":
 		ensure => link,
-		target => '/vagrant/wordpress-develop/build',
+		target => "/vagrant/wordpress-develop/${ name }",
 		notify => Service['nginx'],
-		require => Exec['grunt build'],
-	}
-
-	# Symlink /src into the nginx root.
-	file { '/vagrant/src':
-		ensure => link,
-		target => '/vagrant/wordpress-develop/src',
-		notify => Service['nginx'],
-		require => Exec['grunt build --dev'],
+		require => Exec[ "grunt ${ grunt_command }" ],
 	}
 }

--- a/modules/core-dev/manifests/build.pp
+++ b/modules/core-dev/manifests/build.pp
@@ -4,7 +4,6 @@ class core-dev::build () {
 		command => '/usr/bin/npm install',
 		cwd     => '/vagrant/wordpress-develop',
 		user    => 'vagrant',
-		creates => '/vagrant/wordpress-develop/package-lock.json',
 	}
 
 	# Run grunt to build the project into /vagrant/wordpress-develop/build.

--- a/modules/core-dev/manifests/init.pp
+++ b/modules/core-dev/manifests/init.pp
@@ -6,35 +6,54 @@ class core-dev (
 		config => $config,
 	}
 
-	class { 'core-dev::build':
-		require => [
-			Class['core-dev::repository'],
-			Class['grunt'],
-			Class['npm'],
-		],
+	exec { 'upgrade npm':
+		command => '/usr/bin/npm install -g npm',
+		user    => 'root',
+		require => Class['npm'],
+	}
+
+	exec { 'npm install':
+		command => '/usr/bin/npm install',
+		cwd     => '/vagrant/wordpress-develop',
+		user    => 'vagrant',
+		require => Exec['upgrade npm'],
+	}
+
+	core-dev::build { 'src':
+		grunt_command => 'build --dev',
+		require       => Exec['npm install'],
+	}
+
+	core-dev::build { 'build':
+		grunt_command => 'build',
+		require       => Exec['npm install'],
 	}
 
 	core-dev::site { "${ config['hosts'][0] }/src":
 		sitename          => 'WordPress Develop (source)',
 		location          => '/vagrant/wordpress-develop/src',
 		database          => "${ config[database][name] }_src",
+		# database          => config[database][name],
 		database_user     => $config[database][user],
 		database_password => $config[database][password],
 		admin_user        => $config[admin][user],
 		admin_email       => $config[admin][email],
 		admin_password    => $config[admin][password],
+
+		require           => Core-dev::Build['src'],
 	}
 
 	core-dev::site { "${ config['hosts'][0] }/build":
 		sitename          => 'WordPress Develop (build)',
 		location          => '/vagrant/wordpress-develop/build',
 		database          => "${ config[database][name] }_build",
+		# database          => config[database][name],
 		database_user     => $config[database][user],
 		database_password => $config[database][password],
 		admin_user        => $config[admin][user],
 		admin_email       => $config[admin][email],
 		admin_password    => $config[admin][password],
-		# Build task must complete before /build site can be registered.
-		require => Class['core-dev::build'],
+
+		require           => Core-dev::Build['build'],
 	}
 }

--- a/modules/core-dev/manifests/init.pp
+++ b/modules/core-dev/manifests/init.pp
@@ -6,6 +6,15 @@ class core-dev (
 		config => $config,
 	}
 
+	core-dev::tests { 'prepare unit test environment':
+		database          => "${ config[database][name] }_tests",
+		database_user     => $config[database][user],
+		database_password => $config[database][password],
+		database_host     => 'localhost',
+		database_prefix   => 'wptests_',
+		require           => Class['core-dev::repository'],
+	}
+
 	exec { 'upgrade npm':
 		command => '/usr/bin/npm install -g npm',
 		user    => 'root',

--- a/modules/core-dev/manifests/site.pp
+++ b/modules/core-dev/manifests/site.pp
@@ -1,15 +1,17 @@
 # Install and configure our WordPress site.
 define core-dev::site (
+	$location,
+	$sitename,
+
 	$database,
-	$database_user = 'root',
-	$database_password = 'password',
+	$database_user = 'wordpress',
+	$database_password = 'vagrantpassword',
 	$database_host = 'localhost',
+	$database_prefix = 'wp_',
+
 	$admin_user,
 	$admin_email,
 	$admin_password,
-
-	$location,
-	$sitename,
 ) {
 	mysql::db { $database:
 		user     => $database_user,
@@ -29,9 +31,9 @@ define core-dev::site (
 		admin_user     => $admin_user,
 		admin_email    => $admin_email,
 		admin_password => $admin_password,
-		require => [
-			Class['chassis::php'],
+		require        => [
+			File["${ location }/wp-config.php"],
 			Mysql::Db[$database],
-		]
+		],
 	}
 }

--- a/modules/core-dev/manifests/site.pp
+++ b/modules/core-dev/manifests/site.pp
@@ -1,0 +1,37 @@
+# Install and configure our WordPress site.
+define core-dev::site (
+	$database,
+	$database_user = 'root',
+	$database_password = 'password',
+	$database_host = 'localhost',
+	$admin_user,
+	$admin_email,
+	$admin_password,
+
+	$location,
+	$sitename,
+) {
+	mysql::db { $database:
+		user     => $database_user,
+		password => $database_password,
+		host     => $database_host,
+		grant    => ['all'],
+	}
+
+	file { "${ location }/wp-config.php":
+		content => template('core-dev/wp-config.php.erb'),
+	}
+
+	wp::site { $name:
+		url            => "http://${name}/",
+		sitename       => $sitename,
+		location       => $location,
+		admin_user     => $admin_user,
+		admin_email    => $admin_email,
+		admin_password => $admin_password,
+		require => [
+			Class['chassis::php'],
+			Mysql::Db[$database],
+		]
+	}
+}

--- a/modules/core-dev/manifests/tests.pp
+++ b/modules/core-dev/manifests/tests.pp
@@ -1,0 +1,39 @@
+include vcsrepo
+
+define core-dev::tests (
+	$database = 'wordpress_tests',
+	$database_user = 'wordpress',
+	$database_password = 'vagrantpassword',
+	$database_host = 'localhost',
+	$database_prefix = 'wptests_',
+
+	$tests_domain = 'example.org',
+	$tests_email = 'admin@example.org',
+	$tests_title = 'Test Blog',
+) {
+	mysql::db { $database:
+		user     => $database_user,
+		password => $database_password,
+		host     => $database_host,
+		grant    => ['all'],
+	}
+
+	file { '/vagrant/wordpress-develop/wp-tests-config.php':
+		content => template('core-dev/wp-tests-config.php.erb'),
+	}
+
+	# See
+	vcsrepo { '/vagrant/wordpress-develop/tests/phpunit/data/plugins/wordpress-importer':
+		ensure   => present,
+		provider => svn,
+		source   => 'https://plugins.svn.wordpress.org/wordpress-importer/trunk/',
+		user     => 'vagrant',
+	}
+
+	# wp::plugin { 'wordpress-importer':
+	# 	# Necessary for the tests to pass but need not be installed
+	# 	ensure   => installed,
+	# 	location => '/vagrant/wordpress-develop/src',
+	# 	require  => Class['wp'],
+	# }
+}

--- a/modules/core-dev/templates/wp-config.php.erb
+++ b/modules/core-dev/templates/wp-config.php.erb
@@ -26,7 +26,16 @@ define( 'DB_HOST', 'localhost' );
 define( 'DB_CHARSET', 'utf8' );
 define( 'DB_COLLATE', '' );
 
-$table_prefix = 'wp_';
+/*
+<%= @name %>
+<%= @sitename %>
+<%= @location %>
+<%= @admin_email %>
+<%= @admin_user %>
+<%= @admin_password %>
+*/
+
+$table_prefix = '<%= @database_prefix %>';
 
 // =====================================
 // Errors

--- a/modules/core-dev/templates/wp-config.php.erb
+++ b/modules/core-dev/templates/wp-config.php.erb
@@ -1,0 +1,52 @@
+<?php
+// ===================================================
+// Load database info and local development parameters
+// ===================================================
+$chassisdir = '/vagrant';
+
+if ( file_exists( $chassisdir . '/local-config.php' ) ) {
+	define( 'WP_LOCAL_DEV', true );
+	include( $chassisdir . '/local-config.php' );
+}
+
+// =======================
+// Load Chassis extensions
+// =======================
+if ( file_exists( $chassisdir . '/local-config-extensions.php' ) ) {
+	include( $chassisdir . '/local-config-extensions.php' );
+}
+
+// ==================
+// Configure Database
+// ==================
+define( 'DB_NAME', '<%= @database %>' );
+define( 'DB_USER', '<%= @database_user %>' );
+define( 'DB_PASSWORD', '<%= @database_password %>' );
+define( 'DB_HOST', 'localhost' );
+define( 'DB_CHARSET', 'utf8' );
+define( 'DB_COLLATE', '' );
+
+$table_prefix = 'wp_';
+
+// =====================================
+// Errors
+// Show/hide errors for local/production
+// =====================================
+if ( WP_LOCAL_DEV ) {
+	defined( 'WP_DEBUG' ) or define( 'WP_DEBUG', true );
+}
+// Only override if not already set
+elseif ( ! defined( 'WP_DEBUG_DISPLAY' ) ) {
+	ini_set( 'display_errors', 0 );
+	define( 'WP_DEBUG_DISPLAY', false );
+}
+
+/* That's all, stop editing! Happy publishing. */
+
+/** Absolute path to the WordPress directory. */
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __FILE__ ) . '/' );
+}
+
+/** Sets up WordPress vars and included files. */
+require_once( ABSPATH . 'wp-settings.php' );

--- a/modules/core-dev/templates/wp-tests-config.php.erb
+++ b/modules/core-dev/templates/wp-tests-config.php.erb
@@ -1,0 +1,68 @@
+<?php
+
+/* Path to the WordPress codebase you'd like to test. Add a forward slash in the end. */
+if ( defined( 'WP_RUN_CORE_TESTS' ) && WP_RUN_CORE_TESTS ) {
+	define( 'ABSPATH', dirname( __FILE__ ) . '/build/' );
+} else {
+	define( 'ABSPATH', dirname( __FILE__ ) . '/src/' );
+}
+
+/*
+ * Path to the theme to test with.
+ *
+ * The 'default' theme is symlinked from test/phpunit/data/themedir1/default into
+ * the themes directory of the WordPress installation defined above.
+ */
+define( 'WP_DEFAULT_THEME', 'default' );
+
+// Test with multisite enabled.
+// Alternatively, use the tests/phpunit/multisite.xml configuration file.
+// define( 'WP_TESTS_MULTISITE', true );
+
+// Force known bugs to be run.
+// Tests with an associated Trac ticket that is still open are normally skipped.
+// define( 'WP_TESTS_FORCE_KNOWN_BUGS', true );
+
+// Test with WordPress debug mode (default).
+define( 'WP_DEBUG', true );
+
+// ** MySQL settings ** //
+
+// This configuration file will be used by the copy of WordPress being tested.
+// wordpress/wp-config.php will be ignored.
+
+// WARNING WARNING WARNING!
+// These tests will DROP ALL TABLES in the database with the prefix named below.
+// DO NOT use a production database or one that is shared with something else.
+
+define( 'DB_NAME', '<%= @database %>' );
+define( 'DB_USER', '<%= @database_user %>' );
+define( 'DB_PASSWORD', '<%= @database_password %>' );
+define( 'DB_HOST', '<%= @database_host %>' );
+define( 'DB_CHARSET', 'utf8' );
+define( 'DB_COLLATE', '' );
+
+// /**#@+
+//  * Authentication Unique Keys and Salts.
+//  *
+//  * Change these to different unique phrases!
+//  * You can generate these using the {@link https://api.wordpress.org/secret-key/1.1/salt/ WordPress.org secret-key service}
+//  */
+// define( 'AUTH_KEY',         'put your unique phrase here' );
+// define( 'SECURE_AUTH_KEY',  'put your unique phrase here' );
+// define( 'LOGGED_IN_KEY',    'put your unique phrase here' );
+// define( 'NONCE_KEY',        'put your unique phrase here' );
+// define( 'AUTH_SALT',        'put your unique phrase here' );
+// define( 'SECURE_AUTH_SALT', 'put your unique phrase here' );
+// define( 'LOGGED_IN_SALT',   'put your unique phrase here' );
+// define( 'NONCE_SALT',       'put your unique phrase here' );
+
+$table_prefix = '<%= database_prefix %>';   // Only numbers, letters, and underscores please!
+
+define( 'WP_TESTS_DOMAIN', '<%= @tests_domain %>' );
+define( 'WP_TESTS_EMAIL', '<%= @tests_email %>' );
+define( 'WP_TESTS_TITLE', '<%= @tests_title %>' );
+
+define( 'WP_PHP_BINARY', 'php' );
+
+define( 'WPLANG', '' );


### PR DESCRIPTION
I ran into a lot of trouble trying to understand how to broadcast new domains or subdomains, so this begins a new approach where we serve the two sites as `hostname.local/src` and `hostname.local/build`. This initially worked quite well, and the `src` site seems to install properly, but the `build` site fails -- the error log implies the `wp install` command within the `build` directory is trying to use the wrong database, and I can't for the life of me figure out why or where it's coming from.

Additionally, the `wp-config.php` files in `src` and `build` may need to be centralized in one context-aware file in the `/vagrant/wordpress-develop` directory, because the `build` directory is I believe wiped when `grunt` gets run.