### PR TITLE
Ignore sniffs in tests config to prevent `CapitalPDangit` false positives.

### DIFF
--- a/modules/core-dev/templates/wp-tests-config.php.erb
+++ b/modules/core-dev/templates/wp-tests-config.php.erb
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 
 /* Path to the WordPress codebase you'd like to test. Add a forward slash in the end. */
 if ( defined( 'WP_RUN_CORE_TESTS' ) && WP_RUN_CORE_TESTS ) {


### PR DESCRIPTION
The `grunt precommit` command includes running the `phpcbf` command. In the test config file this causes the database username to be changed to `define( 'DB_USER', ‘WordPress’ );`, breaking the phpunit tests.

Disabling sniffs on this file allows phpunit to run.